### PR TITLE
doc: add docker requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You must have a valid [trainML account](https://app.trainml.ai). On the [account
 
 > Creating resources on the trainML platform requires a non-zero credit balance. To purchase credits or sign-up for automatic credit top-ups, visit the [billing page](https://app.trainml.ai/account/billing).
 
-> Creating model with the SDK require Docker installed and running in the machine you use the SDK, if you need it in Colab [check this tutorial](https://gist.github.com/mwufi/6718b30761cd109f9aff04c5144eb885)
+> Creating model with the SDK require Docker installed and running in the machine you use the SDK.
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You must have a valid [trainML account](https://app.trainml.ai). On the [account
 
 > Creating resources on the trainML platform requires a non-zero credit balance. To purchase credits or sign-up for automatic credit top-ups, visit the [billing page](https://app.trainml.ai/account/billing).
 
+> Creating model with the SDK require Docker installed and running in the machine you use the SDK, if you need it in Colab [check this tutorial](https://gist.github.com/mwufi/6718b30761cd109f9aff04c5144eb885)
+
 ### Methods
 
 #### Credentials File


### PR DESCRIPTION
While running trainml in colab i discovered Docker was needed to upload a model, so i made the README explicit about it